### PR TITLE
Base image updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/ukhomeofficedigital/centos-base
-MAINTAINER billie@purplebooth.co.uk
+MAINTAINER tim.gent@digital.homeoffice.gov.uk
 
 # Install Ruby
 RUN yum -y install ruby ruby-devel gem rubygems unzip gcc rpm-build wget && yum groupinstall "Development Tools" -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/docker-centos-base
+FROM quay.io/ukhomeofficedigital/centos-base
 MAINTAINER billie@purplebooth.co.uk
 
 # Install Ruby


### PR DESCRIPTION
"docker-centos-base" was removed from quay because of duplication. The correct image to use is centos-base, which is what this update does
